### PR TITLE
Alteração do caminho das fonts e imgs do css para caminhos relativos

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,7 +172,7 @@
 
                 <p class="lead description-card"> timer para cubo magic ele registra tempso de cubo magico e salva em
                   tabelas</p>
-                <a href=".https://geovaniorsoli.github.io/Timer-cubomagico/" target="_blank"
+                <a href="https://geovaniorsoli.github.io/Timer-cubomagico/" target="_blank"
                   rel="noopener noreferrer"><button class="button-link-card">Conheça o projeto</button></a>
               </div>
 

--- a/style/style.css
+++ b/style/style.css
@@ -1,6 +1,6 @@
 @font-face {
     font-family: "sfpro";
-    src: url(./font/SF-Pro-Display-Medium.otf);
+    src: url(../font/SF-Pro-Display-Medium.otf);
 }
 
 body{
@@ -118,7 +118,7 @@ body{
 }
 
 .project-session {
-    background-image: url(/img/background/background.png);
+    background-image: url(../img/background/background.png);
     background-size: cover;
     background-position: center;
     background-repeat: no-repeat;


### PR DESCRIPTION
Utilizei caminhos relativos para fazer o acesso a font e a img de background, isso torna possível utilizar esses caminhos não somente em ambiente de desenvolvimento, mas será possível usar em ambiente de produção também.